### PR TITLE
Add organizations support for multi-tenancy (Keycloak 26+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support for managing Organizations (Keycloak 26+ only) [#1286](https://github.com/adorsys/keycloak-config-cli/issues/1286)
+  - Create, update, and delete organizations with domains and attributes
+  - Link identity providers to organizations
+  - Support for managed properties (full/no-delete modes)
+  - Automatic normalization of organization data
 
 ## [6.4.0] - 2025-02-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,6 +31,32 @@ The config files are based on the keycloak export files. You can use them to re-
 
 [moped.json](./contrib/example-config/moped.json) is a full working example file you can consider. Other examples are located in the [test resources](./src/test/resources/import-files).
 
+### Organizations (Keycloak 26+)
+
+Organizations can be configured to support multi-tenancy:
+
+```json
+{
+  "realm": "my-realm",
+  "organizations": [
+    {
+      "alias": "my-org",
+      "name": "My Organization",
+      "enabled": true,
+      "description": "Organization description",
+      "redirectUrl": "https://my-org.example.com",
+      "domains": [
+        {"name": "example.com", "verified": true}
+      ],
+      "attributes": {
+        "contactEmail": ["admin@example.com"]
+      },
+      "identityProviders": ["existing-idp-alias"]
+    }
+  ]
+}
+```
+
 ## Variable Substitution
 
 keycloak-config-cli supports variable substitution of config files. This could be enabled by `import.var-substitution.enabled=true` (**disabled by default**).

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -57,6 +57,9 @@
 | Synchronize user profile                           | 5.4.0 | Synchronize the user profile configuration defined on the realm configuration                            |
 | Synchronize client-policies                        | 5.6.0 | Synchronize the client-policies (clientProfiles and clientPolicies) while updating realms                |
 | Synchronize message bundles                        | 5.12.0 | Synchronize message bundles defined on the realm configuration                                           |
+| Add organizations                                  | x.x.x | Add organizations with domains and identity provider links (Keycloak 26+ only)                           |
+| Update organizations                               | x.x.x | Update organization properties, domains, and identity provider links (Keycloak 26+ only)                 |
+| Remove organizations                               | x.x.x | Remove organizations while updating realms (Keycloak 26+ only)                                           |
 | Normalize realm exports                            | x.x.x | Normalize a full realm export to be more minimal                                                         |
 
 # Specificities
@@ -86,6 +89,48 @@ So if you need this, you have to configure it like :
   }
 }
 ```
+
+# Organizations (Keycloak 26+ only)
+
+Organizations support multi-tenancy in Keycloak by grouping users and identity providers. This feature is only available in Keycloak 26 and later versions.
+
+## Organization Configuration
+
+```json
+{
+  "organizations": [
+    {
+      "alias": "my-org",
+      "name": "My Organization",
+      "enabled": true,
+      "description": "Organization description",
+      "redirectUrl": "https://my-org.example.com",
+      "domains": [
+        {
+          "name": "my-org.com",
+          "verified": true
+        }
+      ],
+      "attributes": {
+        "key": ["value1", "value2"]
+      },
+      "identityProviders": ["saml-idp", "oidc-idp"]
+    }
+  ]
+}
+```
+
+## Key Features:
+- **Domains**: Organizations can have multiple domains with verification status
+- **Identity Providers**: Link existing identity providers to organizations by their alias
+- **Attributes**: Support for multi-valued attributes
+- **Managed Mode**: Organizations support full/no-delete managed modes
+
+## Important Notes:
+- Organizations must be imported AFTER identity providers since they reference IdPs by alias
+- The `enabled` field defaults to `true` if not specified
+- Organization aliases are normalized (lowercase, spaces replaced with hyphens)
+- Domain names are normalized to lowercase
 
 # User - initial password
 

--- a/docs/MANAGED.md
+++ b/docs/MANAGED.md
@@ -59,6 +59,7 @@ In some cases, it is required to include some Keycloak defaults because keycloak
 | Clients Authorization Policies   | -                                                                                | `client-authorization-policies`  |
 | Clients Authorization Scopes     | -                                                                                | `client-authorization-scopes`    |
 | Message Bundles                 | Only message bundles imported with config-cli will be managed/deleted.         | `message-bundles`                |
+| Organizations                   | Organizations with domains and identity provider links (Keycloak 26+ only).     | `organization`                   |
 
 ### Disabling Deletion of Managed Entities
 

--- a/src/main/java/de/adorsys/keycloak/config/model/OrganizationDomainRepresentation.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/OrganizationDomainRepresentation.java
@@ -1,0 +1,64 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.model;
+
+import java.util.Objects;
+
+public class OrganizationDomainRepresentation {
+    private String name;
+    private Boolean verified;
+
+    public OrganizationDomainRepresentation() {
+    }
+
+    public OrganizationDomainRepresentation(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean isVerified() {
+        return verified;
+    }
+
+    public void setVerified(Boolean verified) {
+        this.verified = verified;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrganizationDomainRepresentation that = (OrganizationDomainRepresentation) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/model/OrganizationRepresentation.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/OrganizationRepresentation.java
@@ -1,0 +1,172 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.model;
+
+import java.util.*;
+
+/**
+ * Represents a Keycloak Organization entity for multi-tenancy support.
+ * Organizations group users and identity providers under a common domain.
+ * Available in Keycloak 26+.
+ */
+public class OrganizationRepresentation {
+    private String id;
+    private String name;
+    private String alias;
+    private Boolean enabled;
+    private String description;
+    private String redirectUrl;
+    private Map<String, List<String>> attributes;
+    private Set<OrganizationDomainRepresentation> domains;
+    private List<String> identityProviders;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRedirectUrl() {
+        return redirectUrl;
+    }
+
+    public void setRedirectUrl(String redirectUrl) {
+        this.redirectUrl = redirectUrl;
+    }
+
+    public Map<String, List<String>> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, List<String>> attributes) {
+        this.attributes = attributes;
+    }
+
+    public void singleAttribute(String name, String value) {
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        attributes.put(name, Collections.singletonList(value));
+    }
+
+    public Set<OrganizationDomainRepresentation> getDomains() {
+        return domains;
+    }
+
+    public void setDomains(Set<OrganizationDomainRepresentation> domains) {
+        this.domains = domains;
+    }
+
+    public OrganizationDomainRepresentation getDomain(String name) {
+        if (domains == null || name == null) {
+            return null;
+        }
+        return domains.stream()
+                .filter(domain -> domain != null && name.equals(domain.getName()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void addDomain(OrganizationDomainRepresentation domain) {
+        if (domain == null) {
+            return;
+        }
+        if (domains == null) {
+            domains = new HashSet<>();
+        }
+        domains.add(domain);
+    }
+
+    public void removeDomain(OrganizationDomainRepresentation domain) {
+        if (domains != null) {
+            domains.remove(domain);
+        }
+    }
+
+    public List<String> getIdentityProviders() {
+        return identityProviders;
+    }
+
+    public void setIdentityProviders(List<String> identityProviders) {
+        this.identityProviders = identityProviders;
+    }
+
+    public void addIdentityProvider(String identityProviderAlias) {
+        if (identityProviders == null) {
+            identityProviders = new ArrayList<>();
+        }
+        if (!identityProviders.contains(identityProviderAlias)) {
+            identityProviders.add(identityProviderAlias);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrganizationRepresentation that = (OrganizationRepresentation) o;
+        // Use ID if available, otherwise fall back to alias
+        if (id != null && that.id != null) {
+            return Objects.equals(id, that.id);
+        }
+        return Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        // Use ID if available, otherwise fall back to alias
+        return Objects.hash(id != null ? id : alias);
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/model/RealmImport.java
@@ -2,7 +2,7 @@
  * ---license-start
  * keycloak-config-cli
  * ---
- * Copyright (C) 2017 - 2021 adorsys GmbH & Co. KG @ https://adorsys.com
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
  * ---
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ public class RealmImport extends RealmRepresentation {
 
     private Map<String, Map<String, String>> messageBundles;
 
+    private List<OrganizationRepresentation> organizationList;
+
     private String checksum;
     private String source;
 
@@ -76,6 +78,16 @@ public class RealmImport extends RealmRepresentation {
 
     public UPConfig getUserProfile() {
         return userProfile;
+    }
+
+    public List<OrganizationRepresentation> getOrganizationList() {
+        return organizationList;
+    }
+
+    @SuppressWarnings("unused")
+    @JsonSetter("organizations")
+    public void setOrganizationList(List<OrganizationRepresentation> organizationList) {
+        this.organizationList = organizationList;
     }
 
     @JsonIgnore

--- a/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
+++ b/src/main/java/de/adorsys/keycloak/config/properties/ImportConfigProperties.java
@@ -163,6 +163,9 @@ public class ImportConfigProperties {
         @NotNull
         private final ImportManagedPropertiesValues messageBundles;
 
+        @NotNull
+        private final ImportManagedPropertiesValues organization;
+
         public ImportManagedProperties(@DefaultValue("FULL") ImportManagedPropertiesValues requiredAction,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues group,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientScope,
@@ -178,7 +181,8 @@ public class ImportConfigProperties {
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationResources,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationPolicies,
                                        @DefaultValue("FULL") ImportManagedPropertiesValues clientAuthorizationScopes,
-                                       @DefaultValue("FULL") ImportManagedPropertiesValues messageBundles) {
+                                       @DefaultValue("FULL") ImportManagedPropertiesValues messageBundles,
+                                       @DefaultValue("FULL") ImportManagedPropertiesValues organization) {
             this.requiredAction = requiredAction;
             this.group = group;
             this.clientScope = clientScope;
@@ -195,6 +199,7 @@ public class ImportConfigProperties {
             this.clientAuthorizationPolicies = clientAuthorizationPolicies;
             this.clientAuthorizationScopes = clientAuthorizationScopes;
             this.messageBundles = messageBundles;
+            this.organization = organization;
         }
 
         public ImportManagedPropertiesValues getRequiredAction() {
@@ -259,6 +264,10 @@ public class ImportConfigProperties {
 
         public ImportManagedPropertiesValues getMessageBundles() {
             return messageBundles;
+        }
+
+        public ImportManagedPropertiesValues getOrganization() {
+            return organization;
         }
 
         public enum ImportManagedPropertiesValues {

--- a/src/main/java/de/adorsys/keycloak/config/repository/OrganizationRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/OrganizationRepository.java
@@ -1,0 +1,180 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.repository;
+
+import de.adorsys.keycloak.config.exception.KeycloakRepositoryException;
+import de.adorsys.keycloak.config.model.OrganizationRepresentation;
+import de.adorsys.keycloak.config.provider.KeycloakProvider;
+import de.adorsys.keycloak.config.resource.OrganizationApi;
+import de.adorsys.keycloak.config.resource.OrganizationIdentityProviderApi;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class OrganizationRepository {
+    private static final int HTTP_CREATED = 201;
+    private static final int HTTP_NO_CONTENT = 204;
+
+    private final KeycloakProvider keycloakProvider;
+
+    @Autowired
+    public OrganizationRepository(KeycloakProvider keycloakProvider) {
+        this.keycloakProvider = keycloakProvider;
+    }
+
+    public void create(String realm, OrganizationRepresentation organization) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        
+        try (Response response = api.create(realm, organization)) {
+            if (response.getStatus() != HTTP_CREATED) {
+                throw new KeycloakRepositoryException(
+                        String.format("Failed to create organization '%s' in realm '%s'. Status: %d",
+                                organization.getAlias(), realm, response.getStatus()));
+            }
+            
+            if (response.getLocation() != null) {
+                String location = response.getLocation().toString();
+                String id = location.substring(location.lastIndexOf('/') + 1);
+                organization.setId(id);
+            }
+        }
+    }
+
+    public void update(String realm, OrganizationRepresentation organization) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        
+        try {
+            api.update(realm, organization.getId(), organization);
+        } catch (NotFoundException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot update organization '%s' in realm '%s': Not found",
+                            organization.getAlias(), realm), e);
+        }
+    }
+
+    public void delete(String realm, String organizationId) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        
+        try {
+            api.delete(realm, organizationId);
+        } catch (NotFoundException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot delete organization with id '%s' in realm '%s': Not found",
+                            organizationId, realm), e);
+        }
+    }
+
+    public OrganizationRepresentation get(String realm, String organizationId) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        
+        try {
+            return api.get(realm, organizationId);
+        } catch (NotFoundException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot get organization with id '%s' in realm '%s': Not found",
+                            organizationId, realm), e);
+        }
+    }
+
+    public List<OrganizationRepresentation> getAll(String realm) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        List<OrganizationRepresentation> organizations = api.search(realm, null, null, null, null, null, false);
+        return organizations != null ? organizations : new ArrayList<>();
+    }
+
+    public Optional<OrganizationRepresentation> search(String realm, String searchValue) {
+        OrganizationApi api = keycloakProvider.getCustomApiProxy(OrganizationApi.class);
+        
+        // First try exact match
+        List<OrganizationRepresentation> exactResults = api.search(realm, searchValue, null, true, null, null, false);
+        if (!exactResults.isEmpty()) {
+            return Optional.of(exactResults.get(0));
+        }
+        
+        // If no exact match, try partial match
+        List<OrganizationRepresentation> partialResults = api.search(realm, searchValue, null, false, null, null, false);
+        return partialResults.stream()
+                .filter(org -> searchValue.equals(org.getName()) || searchValue.equals(org.getAlias()))
+                .findFirst();
+    }
+
+    public Optional<OrganizationRepresentation> getByAlias(String realm, String alias) {
+        return search(realm, alias);
+    }
+
+    // Identity Provider management methods
+
+    public void linkIdentityProvider(String realm, String organizationId, String identityProviderAlias) {
+        OrganizationIdentityProviderApi api = keycloakProvider.getCustomApiProxy(OrganizationIdentityProviderApi.class);
+        
+        // Create a minimal representation with just the alias
+        IdentityProviderRepresentation idp = new IdentityProviderRepresentation();
+        idp.setAlias(identityProviderAlias);
+        
+        try (Response response = api.addIdentityProvider(realm, organizationId, idp)) {
+            // API may return either 201 (created) or 204 (no content) on success
+            if (response.getStatus() != HTTP_NO_CONTENT && response.getStatus() != HTTP_CREATED) {
+                throw new KeycloakRepositoryException(
+                        String.format("Failed to link identity provider '%s' to organization '%s' in realm '%s'. Status: %d",
+                                identityProviderAlias, organizationId, realm, response.getStatus()));
+            }
+        } catch (ClientErrorException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot link identity provider '%s' to organization '%s' in realm '%s': %s",
+                            identityProviderAlias, organizationId, realm, e.getMessage()), e);
+        }
+    }
+
+    public void unlinkIdentityProvider(String realm, String organizationId, String identityProviderAlias) {
+        OrganizationIdentityProviderApi api = keycloakProvider.getCustomApiProxy(OrganizationIdentityProviderApi.class);
+        
+        try {
+            api.removeIdentityProvider(realm, organizationId, identityProviderAlias);
+        } catch (NotFoundException e) {
+            // Ignore if already unlinked
+        } catch (ClientErrorException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot unlink identity provider '%s' from organization '%s' in realm '%s': %s",
+                            identityProviderAlias, organizationId, realm, e.getMessage()), e);
+        }
+    }
+
+    public List<IdentityProviderRepresentation> getLinkedIdentityProviders(String realm, String organizationId) {
+        OrganizationIdentityProviderApi api = keycloakProvider.getCustomApiProxy(OrganizationIdentityProviderApi.class);
+        
+        try {
+            List<IdentityProviderRepresentation> providers = api.getIdentityProviders(realm, organizationId);
+            return providers != null ? providers : new ArrayList<>();
+        } catch (NotFoundException e) {
+            throw new KeycloakRepositoryException(
+                    String.format("Cannot get identity providers for organization '%s' in realm '%s': Organization not found",
+                            organizationId, realm), e);
+        }
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/resource/OrganizationApi.java
+++ b/src/main/java/de/adorsys/keycloak/config/resource/OrganizationApi.java
@@ -1,0 +1,71 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.resource;
+
+import de.adorsys.keycloak.config.model.OrganizationRepresentation;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * Custom API interface for Keycloak Organizations management.
+ * This is needed because the Keycloak admin client 26.0.4 doesn't include Organizations API.
+ */
+@Path("/admin/realms/{realm}/organizations")
+public interface OrganizationApi {
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response create(@PathParam("realm") String realm, OrganizationRepresentation organization);
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<OrganizationRepresentation> search(@PathParam("realm") String realm,
+                                           @QueryParam("search") String search,
+                                           @QueryParam("searchQuery") String searchQuery,
+                                           @QueryParam("exact") Boolean exact,
+                                           @QueryParam("first") Integer first,
+                                           @QueryParam("max") Integer max,
+                                           @QueryParam("briefRepresentation") Boolean briefRepresentation);
+
+    @GET
+    @Path("/count")
+    @Produces(MediaType.APPLICATION_JSON)
+    Integer count(@PathParam("realm") String realm,
+                  @QueryParam("search") String search,
+                  @QueryParam("searchQuery") String searchQuery);
+
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    OrganizationRepresentation get(@PathParam("realm") String realm, @PathParam("id") String id);
+
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    void update(@PathParam("realm") String realm, @PathParam("id") String id, OrganizationRepresentation organization);
+
+    @DELETE
+    @Path("/{id}")
+    void delete(@PathParam("realm") String realm, @PathParam("id") String id);
+}

--- a/src/main/java/de/adorsys/keycloak/config/resource/OrganizationIdentityProviderApi.java
+++ b/src/main/java/de/adorsys/keycloak/config/resource/OrganizationIdentityProviderApi.java
@@ -1,0 +1,60 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.resource;
+
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+
+/**
+ * Custom API interface for managing identity providers within organizations.
+ * This is needed because the Keycloak admin client 26.0.4 doesn't include Organizations API.
+ */
+@Path("/admin/realms/{realm}/organizations/{orgId}/identity-providers")
+public interface OrganizationIdentityProviderApi {
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<IdentityProviderRepresentation> getIdentityProviders(@PathParam("realm") String realm,
+                                                              @PathParam("orgId") String orgId);
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    Response addIdentityProvider(@PathParam("realm") String realm,
+                                @PathParam("orgId") String orgId,
+                                IdentityProviderRepresentation identityProvider);
+
+    @GET
+    @Path("/{alias}")
+    @Produces(MediaType.APPLICATION_JSON)
+    IdentityProviderRepresentation getIdentityProvider(@PathParam("realm") String realm,
+                                                       @PathParam("orgId") String orgId,
+                                                       @PathParam("alias") String alias);
+
+    @DELETE
+    @Path("/{alias}")
+    void removeIdentityProvider(@PathParam("realm") String realm,
+                               @PathParam("orgId") String orgId,
+                               @PathParam("alias") String alias);
+}

--- a/src/main/java/de/adorsys/keycloak/config/service/OrganizationImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/OrganizationImportService.java
@@ -1,0 +1,227 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.exception.ImportProcessingException;
+import de.adorsys.keycloak.config.model.OrganizationRepresentation;
+import de.adorsys.keycloak.config.model.RealmImport;
+import de.adorsys.keycloak.config.properties.ImportConfigProperties;
+import de.adorsys.keycloak.config.repository.IdentityProviderRepository;
+import de.adorsys.keycloak.config.repository.OrganizationRepository;
+import de.adorsys.keycloak.config.service.normalize.OrganizationNormalizationService;
+import de.adorsys.keycloak.config.util.CloneUtil;
+import org.keycloak.representations.idm.IdentityProviderRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static de.adorsys.keycloak.config.properties.ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues;
+
+/**
+ * Service responsible for importing Keycloak Organizations.
+ * Handles creation, update, and deletion of organizations based on managed mode.
+ * Organizations must be imported after identity providers due to dependencies.
+ */
+@Service
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class OrganizationImportService {
+    private static final Logger logger = LoggerFactory.getLogger(OrganizationImportService.class);
+
+    private final OrganizationRepository organizationRepository;
+    private final IdentityProviderRepository identityProviderRepository;
+    private final ImportConfigProperties importConfigProperties;
+    private final OrganizationNormalizationService organizationNormalizationService;
+
+    @Autowired
+    public OrganizationImportService(
+            OrganizationRepository organizationRepository,
+            IdentityProviderRepository identityProviderRepository,
+            ImportConfigProperties importConfigProperties,
+            OrganizationNormalizationService organizationNormalizationService
+    ) {
+        this.organizationRepository = organizationRepository;
+        this.identityProviderRepository = identityProviderRepository;
+        this.importConfigProperties = importConfigProperties;
+        this.organizationNormalizationService = organizationNormalizationService;
+    }
+
+    public void doImport(RealmImport realmImport) {
+        List<OrganizationRepresentation> organizations = realmImport.getOrganizationList();
+        if (organizations == null) {
+            return;
+        }
+
+        String realmName = realmImport.getRealm();
+        
+        // Normalize organizations before processing
+        organizations = organizationNormalizationService.normalizeOrganizations(organizations);
+        
+        // First phase: Create/update organizations (and delete if managed mode is FULL)
+        manageOrganizations(realmName, organizations);
+        
+        // Second phase: Link identity providers
+        // This is done separately to ensure all organizations exist before linking
+        for (OrganizationRepresentation organization : organizations) {
+            updateIdentityProviderLinks(realmName, organization);
+        }
+    }
+
+    private void manageOrganizations(String realmName, List<OrganizationRepresentation> organizations) {
+        List<OrganizationRepresentation> existingOrganizations = organizationRepository.getAll(realmName);
+
+        if (importConfigProperties.getManaged().getOrganization() == ImportManagedPropertiesValues.FULL) {
+            deleteOrganizationsMissingInImport(realmName, organizations, existingOrganizations);
+        }
+
+        for (OrganizationRepresentation organization : organizations) {
+            createOrUpdateOrganization(realmName, organization);
+        }
+    }
+
+    private void deleteOrganizationsMissingInImport(
+            String realmName,
+            List<OrganizationRepresentation> importedOrganizations,
+            List<OrganizationRepresentation> existingOrganizations
+    ) {
+        Set<String> importedAliases = importedOrganizations.stream()
+                .map(OrganizationRepresentation::getAlias)
+                .collect(Collectors.toSet());
+
+        for (OrganizationRepresentation existingOrg : existingOrganizations) {
+            if (!importedAliases.contains(existingOrg.getAlias())) {
+                logger.debug("Delete organization '{}' in realm '{}'", existingOrg.getAlias(), realmName);
+                organizationRepository.delete(realmName, existingOrg.getId());
+            }
+        }
+    }
+
+    private void createOrUpdateOrganization(String realmName, OrganizationRepresentation organization) {
+        String organizationAlias = organization.getAlias();
+        
+        if (!StringUtils.hasText(organizationAlias)) {
+            throw new ImportProcessingException("Organization alias cannot be null or empty");
+        }
+        
+        Optional<OrganizationRepresentation> maybeOrganization = organizationRepository.getByAlias(realmName, organizationAlias);
+
+        if (maybeOrganization.isPresent()) {
+            updateOrganizationIfNeeded(realmName, organization, maybeOrganization.get());
+        } else {
+            logger.debug("Create organization '{}' in realm '{}'", organizationAlias, realmName);
+            
+            // Don't send identity providers during creation
+            OrganizationRepresentation orgToCreate = CloneUtil.deepClone(organization);
+            orgToCreate.setIdentityProviders(null);
+            
+            organizationRepository.create(realmName, orgToCreate);
+            
+            // Update the original organization with the generated ID
+            organization.setId(orgToCreate.getId());
+        }
+    }
+
+    private void updateOrganizationIfNeeded(String realmName, OrganizationRepresentation importedOrg, 
+                                           OrganizationRepresentation existingOrg) {
+        String organizationAlias = importedOrg.getAlias();
+        
+        // Set the ID from existing organization
+        importedOrg.setId(existingOrg.getId());
+        
+        // Create a copy without identity providers for comparison
+        OrganizationRepresentation importedWithoutIdps = CloneUtil.deepClone(importedOrg);
+        importedWithoutIdps.setIdentityProviders(null);
+        
+        OrganizationRepresentation existingWithoutIdps = CloneUtil.deepClone(existingOrg);
+        existingWithoutIdps.setIdentityProviders(null);
+        
+        if (!CloneUtil.deepEquals(importedWithoutIdps, existingWithoutIdps)) {
+            logger.debug("Update organization '{}' in realm '{}'", organizationAlias, realmName);
+            organizationRepository.update(realmName, importedWithoutIdps);
+        } else {
+            logger.debug("No need to update organization '{}' in realm '{}'", organizationAlias, realmName);
+        }
+    }
+
+    private void updateIdentityProviderLinks(String realmName, OrganizationRepresentation organization) {
+        if (organization.getId() == null) {
+            // If we don't have an ID, try to get it from the repository
+            Optional<OrganizationRepresentation> maybeOrg = organizationRepository.getByAlias(realmName, organization.getAlias());
+            if (maybeOrg.isPresent()) {
+                organization.setId(maybeOrg.get().getId());
+            } else {
+                logger.warn("Cannot update identity provider links for organization '{}': Organization not found", 
+                            organization.getAlias());
+                return;
+            }
+        }
+
+        String organizationId = organization.getId();
+        List<String> desiredIdpAliases = organization.getIdentityProviders();
+        
+        if (desiredIdpAliases == null) {
+            desiredIdpAliases = Collections.emptyList();
+        }
+        
+        // Get current linked IdPs
+        List<IdentityProviderRepresentation> currentIdps = organizationRepository.getLinkedIdentityProviders(realmName, organizationId);
+        Set<String> currentIdpAliases = currentIdps.stream()
+                .map(IdentityProviderRepresentation::getAlias)
+                .collect(Collectors.toSet());
+        
+        Set<String> desiredIdpAliasesSet = new HashSet<>(desiredIdpAliases);
+        
+        // Link new IdPs
+        for (String idpAlias : desiredIdpAliases) {
+            if (!currentIdpAliases.contains(idpAlias)) {
+                validateIdentityProviderExists(realmName, idpAlias);
+                logger.debug("Link identity provider '{}' to organization '{}' in realm '{}'", 
+                            idpAlias, organization.getAlias(), realmName);
+                organizationRepository.linkIdentityProvider(realmName, organizationId, idpAlias);
+            }
+        }
+        
+        // Unlink removed IdPs (only in FULL managed mode)
+        if (importConfigProperties.getManaged().getOrganization() == ImportManagedPropertiesValues.FULL) {
+            for (String currentIdpAlias : currentIdpAliases) {
+                if (!desiredIdpAliasesSet.contains(currentIdpAlias)) {
+                    logger.debug("Unlink identity provider '{}' from organization '{}' in realm '{}'", 
+                                currentIdpAlias, organization.getAlias(), realmName);
+                    organizationRepository.unlinkIdentityProvider(realmName, organizationId, currentIdpAlias);
+                }
+            }
+        }
+    }
+
+    private void validateIdentityProviderExists(String realmName, String idpAlias) {
+        Optional<IdentityProviderRepresentation> maybeIdp = identityProviderRepository.search(realmName, idpAlias);
+        if (maybeIdp.isEmpty()) {
+            throw new ImportProcessingException(
+                    String.format("Identity provider '%s' does not exist in realm '%s'",
+                            idpAlias, realmName));
+        }
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RealmImportService.java
@@ -61,6 +61,7 @@ public class RealmImportService {
             "defaultOptionalClientScopes",
             "clientProfiles",
             "clientPolicies",
+            "organizations",
     };
 
     private static final Logger logger = LoggerFactory.getLogger(RealmImportService.class);
@@ -87,6 +88,7 @@ public class RealmImportService {
     private final ClientScopeMappingImportService clientScopeMappingImportService;
     private final IdentityProviderImportService identityProviderImportService;
     private final MessageBundleImportService messageBundleImportService;
+    private final OrganizationImportService organizationImportService;
 
     private final ImportConfigProperties importProperties;
 
@@ -115,6 +117,7 @@ public class RealmImportService {
             ClientScopeMappingImportService clientScopeMappingImportService,
             IdentityProviderImportService identityProviderImportService,
             MessageBundleImportService messageBundleImportService,
+            OrganizationImportService organizationImportService,
             OtpPolicyImportService otpPolicyImportService,
             ChecksumService checksumService,
             StateService stateService) {
@@ -138,6 +141,7 @@ public class RealmImportService {
         this.clientScopeMappingImportService = clientScopeMappingImportService;
         this.identityProviderImportService = identityProviderImportService;
         this.messageBundleImportService = messageBundleImportService;
+        this.organizationImportService = organizationImportService;
         this.otpPolicyImportService = otpPolicyImportService;
         this.checksumService = checksumService;
         this.stateService = stateService;
@@ -234,6 +238,7 @@ public class RealmImportService {
         clientImportService.doImportDependencies(realmImport);
         clientScopeImportService.updateDefaultClientScopes(realmImport, existingRealm);
         identityProviderImportService.doImport(realmImport);
+        organizationImportService.doImport(realmImport);
         clientAuthorizationImportService.doImport(realmImport);
         scopeMappingImportService.doImport(realmImport);
         clientScopeMappingImportService.doImport(realmImport);

--- a/src/main/java/de/adorsys/keycloak/config/service/normalize/OrganizationNormalizationService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/normalize/OrganizationNormalizationService.java
@@ -1,0 +1,128 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service.normalize;
+
+import de.adorsys.keycloak.config.model.OrganizationRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.*;
+
+@Service
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "NORMALIZE", matchIfMissing = true)
+public class OrganizationNormalizationService {
+    private static final Logger logger = LoggerFactory.getLogger(OrganizationNormalizationService.class);
+    
+    private static final String WHITESPACE_PATTERN = "\\s+";
+    private static final String INVALID_ALIAS_CHARS_PATTERN = "[^a-z0-9-]";
+    private static final String HYPHEN_REPLACEMENT = "-";
+
+    public List<OrganizationRepresentation> normalizeOrganizations(List<OrganizationRepresentation> organizations) {
+        if (organizations == null) {
+            return null;
+        }
+
+        for (OrganizationRepresentation organization : organizations) {
+            normalizeOrganization(organization);
+        }
+
+        return organizations;
+    }
+
+    private void normalizeOrganization(OrganizationRepresentation organization) {
+        // Set default enabled value if not specified
+        if (organization.getEnabled() == null) {
+            organization.setEnabled(true);
+        }
+
+        // Normalize alias - convert to lowercase and replace spaces with hyphens
+        if (organization.getAlias() != null) {
+            String normalizedAlias = organization.getAlias()
+                    .toLowerCase()
+                    .replaceAll(WHITESPACE_PATTERN, HYPHEN_REPLACEMENT)
+                    .replaceAll(INVALID_ALIAS_CHARS_PATTERN, "");
+            organization.setAlias(normalizedAlias);
+        }
+
+        // Normalize attributes - ensure all values are lists
+        if (organization.getAttributes() != null) {
+            Map<String, List<String>> normalizedAttributes = new HashMap<>();
+            
+            for (Map.Entry<String, List<String>> entry : organization.getAttributes().entrySet()) {
+                String key = entry.getKey();
+                List<String> values = entry.getValue();
+                
+                if (values != null && !values.isEmpty()) {
+                    // Remove null and empty values
+                    List<String> cleanedValues = new ArrayList<>();
+                    for (String value : values) {
+                        if (StringUtils.hasText(value)) {
+                            cleanedValues.add(value.trim());
+                        }
+                    }
+                    
+                    if (!cleanedValues.isEmpty()) {
+                        normalizedAttributes.put(key, cleanedValues);
+                    }
+                }
+            }
+            
+            organization.setAttributes(normalizedAttributes.isEmpty() ? null : normalizedAttributes);
+        }
+
+        // Normalize domains
+        if (organization.getDomains() != null && !organization.getDomains().isEmpty()) {
+            organization.getDomains().forEach(domain -> {
+                if (domain != null && domain.getName() != null) {
+                    // Normalize domain name to lowercase
+                    domain.setName(domain.getName().toLowerCase().trim());
+                }
+            });
+            
+            // Remove any domains with null or empty names
+            organization.getDomains().removeIf(domain -> 
+                domain == null || !StringUtils.hasText(domain.getName())
+            );
+        }
+
+        // Normalize identity provider list
+        if (organization.getIdentityProviders() != null) {
+            // Remove duplicates and nulls
+            List<String> uniqueIdps = new ArrayList<>();
+            Set<String> seen = new HashSet<>();
+            
+            for (String idp : organization.getIdentityProviders()) {
+                if (StringUtils.hasText(idp) && seen.add(idp.trim())) {
+                    uniqueIdps.add(idp.trim());
+                }
+            }
+            
+            organization.setIdentityProviders(uniqueIdps.isEmpty() ? null : uniqueIdps);
+        }
+
+        // Log normalization actions
+        logger.debug("Normalized organization '{}' with alias '{}'", 
+                    organization.getName(), organization.getAlias());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,6 +54,7 @@ import.managed.client-authorization-resources=full
 import.managed.client-authorization-policies=full
 import.managed.client-authorization-scopes=full
 import.managed.message-bundles=full
+import.managed.organization=full
 
 logging.group.http=org.apache.http.wire
 logging.group.realm-config=de.adorsys.keycloak.config.provider.KeycloakImportProvider

--- a/src/test/java/de/adorsys/keycloak/config/service/ImportOrganizationsIT.java
+++ b/src/test/java/de/adorsys/keycloak/config/service/ImportOrganizationsIT.java
@@ -1,0 +1,149 @@
+/*-
+ * ---license-start
+ * keycloak-config-cli
+ * ---
+ * Copyright (C) 2017 - 2025 adorsys GmbH & Co. KG @ https://adorsys.com
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package de.adorsys.keycloak.config.service;
+
+import de.adorsys.keycloak.config.AbstractImportIT;
+import de.adorsys.keycloak.config.exception.ImportProcessingException;
+import de.adorsys.keycloak.config.model.OrganizationRepresentation;
+import de.adorsys.keycloak.config.repository.OrganizationRepository;
+import de.adorsys.keycloak.config.util.VersionUtil;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Integration tests for Organization import functionality.
+ * Note: Organizations are only available in Keycloak 26+
+ */
+@DisabledIf("isKeycloakVersionLessThan26")
+@SuppressWarnings({"java:S5961", "java:S5976"})
+class ImportOrganizationsIT extends AbstractImportIT {
+    private static final String REALM_NAME = "realmWithOrganizations";
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    ImportOrganizationsIT() {
+        this.resourcePath = "import-files/organizations";
+    }
+
+    private static boolean isKeycloakVersionLessThan26() {
+        return VersionUtil.lt(KEYCLOAK_VERSION, "26");
+    }
+
+    @Test
+    @Order(0)
+    void shouldCreateRealmWithOrganization() throws IOException {
+        doImport("00_create_realm_with_organization.json");
+
+        List<OrganizationRepresentation> organizations = organizationRepository.getAll(REALM_NAME);
+        assertThat(organizations, hasSize(1));
+
+        OrganizationRepresentation org = organizations.get(0);
+        assertThat(org.getName(), is("Test Organization"));
+        assertThat(org.getAlias(), is("test-org"));
+        assertThat(org.getEnabled(), is(true));
+        assertThat(org.getDescription(), is("A test organization"));
+        assertThat(org.getRedirectUrl(), is("https://test-org.example.com"));
+
+        // Check domains
+        assertThat(org.getDomains(), hasSize(2));
+        assertThat(org.getDomain("test-org.com"), notNullValue());
+        assertThat(org.getDomain("test-org.com").getVerified(), is(Boolean.TRUE));
+        assertThat(org.getDomain("test-org.org"), notNullValue());
+        assertThat(org.getDomain("test-org.org").getVerified(), is(Boolean.FALSE));
+
+        // Check attributes
+        assertThat(org.getAttributes(), notNullValue());
+        assertThat(org.getAttributes().get("contactEmail"), contains("admin@test-org.com"));
+        assertThat(org.getAttributes().get("contactPhone"), containsInAnyOrder("+1234567890", "+0987654321"));
+    }
+
+    @Test
+    @Order(1)
+    void shouldUpdateOrganization() throws IOException {
+        // Create a JSON that updates the organization
+        doImport("01_update_organization_properties.json");
+
+        Optional<OrganizationRepresentation> maybeOrg = organizationRepository.getByAlias(REALM_NAME, "test-org");
+        assertThat(maybeOrg.isPresent(), is(true));
+
+        OrganizationRepresentation org = maybeOrg.get();
+        assertThat(org.getName(), is("Updated Test Organization"));
+        assertThat(org.getDescription(), is("An updated test organization"));
+        assertThat(org.getRedirectUrl(), is("https://updated.test-org.com"));
+    }
+
+    @Test
+    @Order(2)
+    void shouldAddDomainToOrganization() throws IOException {
+        doImport("02_update_organization_add_domain.json");
+
+        Optional<OrganizationRepresentation> maybeOrg = organizationRepository.getByAlias(REALM_NAME, "test-org");
+        assertThat(maybeOrg.isPresent(), is(true));
+
+        OrganizationRepresentation org = maybeOrg.get();
+        assertThat(org.getDomains(), hasSize(3));
+        assertThat(org.getDomain("test-org.net"), notNullValue());
+        assertThat(org.getDomain("test-org.net").getVerified(), is(Boolean.TRUE));
+    }
+
+    @Test
+    @Order(3)
+    void shouldFailWhenOrganizationHasEmptyAlias() {
+        ImportProcessingException thrown = assertThrows(
+                ImportProcessingException.class,
+                () -> doImport("03_update_organization_empty_alias.json")
+        );
+        
+        assertThat(thrown.getMessage(), containsString("Organization alias cannot be null or empty"));
+    }
+
+    @Test
+    @Order(10)
+    void shouldFailWhenLinkingNonExistentIdentityProvider() {
+        ImportProcessingException thrown = assertThrows(
+                ImportProcessingException.class,
+                () -> doImport("10_update_organization_link_non_existent_idp.json")
+        );
+        
+        assertThat(thrown.getMessage(), containsString("Identity provider does not exist"));
+    }
+
+    @Test
+    @Order(98)
+    void shouldDeleteOrganizationInFullMode() throws IOException {
+        // Assuming we're in FULL mode by default
+        doImport("98_update_realm_remove_organization.json");
+
+        List<OrganizationRepresentation> organizations = organizationRepository.getAll(REALM_NAME);
+        assertThat(organizations, empty());
+    }
+}

--- a/src/test/resources/import-files/organizations/00_create_realm_with_organization.json
+++ b/src/test/resources/import-files/organizations/00_create_realm_with_organization.json
@@ -1,0 +1,27 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": [
+    {
+      "alias": "test-org",
+      "name": "Test Organization",
+      "enabled": true,
+      "description": "A test organization",
+      "redirectUrl": "https://test-org.example.com",
+      "domains": [
+        {
+          "name": "test-org.com",
+          "verified": true
+        },
+        {
+          "name": "test-org.org",
+          "verified": false
+        }
+      ],
+      "attributes": {
+        "contactEmail": ["admin@test-org.com"],
+        "contactPhone": ["+1234567890", "+0987654321"]
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/organizations/01_update_organization_properties.json
+++ b/src/test/resources/import-files/organizations/01_update_organization_properties.json
@@ -1,0 +1,27 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": [
+    {
+      "alias": "test-org",
+      "name": "Updated Test Organization",
+      "enabled": true,
+      "description": "An updated test organization",
+      "redirectUrl": "https://updated.test-org.com",
+      "domains": [
+        {
+          "name": "test-org.com",
+          "verified": true
+        },
+        {
+          "name": "test-org.org",
+          "verified": false
+        }
+      ],
+      "attributes": {
+        "contactEmail": ["admin@test-org.com"],
+        "contactPhone": ["+1234567890", "+0987654321"]
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/organizations/02_update_organization_add_domain.json
+++ b/src/test/resources/import-files/organizations/02_update_organization_add_domain.json
@@ -1,0 +1,31 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": [
+    {
+      "alias": "test-org",
+      "name": "Updated Test Organization",
+      "enabled": true,
+      "description": "An updated test organization",
+      "redirectUrl": "https://updated.test-org.com",
+      "domains": [
+        {
+          "name": "test-org.com",
+          "verified": true
+        },
+        {
+          "name": "test-org.org",
+          "verified": false
+        },
+        {
+          "name": "test-org.net",
+          "verified": true
+        }
+      ],
+      "attributes": {
+        "contactEmail": ["admin@test-org.com"],
+        "contactPhone": ["+1234567890", "+0987654321"]
+      }
+    }
+  ]
+}

--- a/src/test/resources/import-files/organizations/03_update_organization_empty_alias.json
+++ b/src/test/resources/import-files/organizations/03_update_organization_empty_alias.json
@@ -1,0 +1,11 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": [
+    {
+      "alias": "",
+      "name": "Organization without alias",
+      "enabled": true
+    }
+  ]
+}

--- a/src/test/resources/import-files/organizations/10_update_organization_link_non_existent_idp.json
+++ b/src/test/resources/import-files/organizations/10_update_organization_link_non_existent_idp.json
@@ -1,0 +1,20 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": [
+    {
+      "alias": "test-org",
+      "name": "Updated Test Organization",
+      "enabled": true,
+      "description": "An updated test organization",
+      "redirectUrl": "https://updated.test-org.com",
+      "domains": [
+        {
+          "name": "test-org.com",
+          "verified": true
+        }
+      ],
+      "identityProviders": ["non-existent-idp"]
+    }
+  ]
+}

--- a/src/test/resources/import-files/organizations/98_update_realm_remove_organization.json
+++ b/src/test/resources/import-files/organizations/98_update_realm_remove_organization.json
@@ -1,0 +1,5 @@
+{
+  "realm": "realmWithOrganizations",
+  "enabled": true,
+  "organizations": []
+}


### PR DESCRIPTION
Enable declarative configuration of Keycloak organizations to support multi-tenant architectures. Organizations group users and identity providers under common domains, allowing better tenant isolation.

Key capabilities:
- Create and manage organizations with domains and attributes
- Link identity providers to organizations
- Support for verified/unverified domain status
- Full managed mode with automatic cleanup
- Comprehensive test coverage

This feature requires Keycloak 26 or later.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect any significant (and particularly user-facing) changes introduced by this PR
